### PR TITLE
feat: add some `async`, `overload`, `enum` support

### DIFF
--- a/lua/docgen/grammar/luacats.lua
+++ b/lua/docgen/grammar/luacats.lua
@@ -91,6 +91,7 @@ local grammar = P({
     + annot("operator", ty_name * opt(paren(Cg(v.ctype, "argtype"))) * colon * v.ctype)
     + annot(access)
     + annot("deprecated")
+    + annot("async")
     + annot("alias", ty_name * opt(ws * v.ctype))
     + annot("enum", ty_name)
     + annot("overload", v.ctype)

--- a/lua/docgen/parser.lua
+++ b/lua/docgen/parser.lua
@@ -34,6 +34,8 @@ local luacats_grammar = require("docgen.grammar.luacats")
 --- @field modvar? string
 --- @field classvar? string
 --- @field deprecated? true
+--- @field async? true
+--- @field overloads? string[]
 --- @field since? string -- need?
 --- @field attrs? string[] -- need?
 --- @field nodoc? true
@@ -47,6 +49,7 @@ local luacats_grammar = require("docgen.grammar.luacats")
 --- @field type string
 --- @field desc string
 --- @field access? 'private'|'package'|'protected'
+--- @field overloads? string[]
 
 --- @class docgen.parser.class
 --- @field kind 'class'
@@ -181,6 +184,11 @@ local function process_doc_line(line, state)
     cur_obj.access = "protected"
   elseif kind == "deprecated" then
     cur_obj.deprecated = true
+  elseif kind == "async" then
+    cur_obj.async = true
+  elseif kind == "overload" then
+    cur_obj.overloads = cur_obj.overloads or {}
+    table.insert(cur_obj.overloads, parsed.type)
   elseif kind == "inlinedoc" then
     cur_obj.inlinedoc = true
   elseif kind == "nodoc" then
@@ -208,16 +216,16 @@ local function process_doc_line(line, state)
       desc = parsed.desc,
     }
   elseif kind == "enum" then
-    -- TODO
+    -- Enums do not contribute output today. Clear any pending doc state so
+    -- invalid follow-on annotations do not attach to a throwaway object.
     state.doc_lines = nil
-  elseif
-    vim.tbl_contains({
-      "diagnostic",
-      "cast",
-      "overload",
-      "meta",
-    }, kind)
-  then
+    state.cur_obj = nil
+    return
+  elseif vim.tbl_contains({
+    "diagnostic",
+    "cast",
+    "meta",
+  }, kind) then
     -- Ignore
     return
   elseif kind == "generic" then
@@ -232,9 +240,11 @@ end
 --- @return docgen.parser.field
 local function fun2field(fun)
   local parts = { "fun(" }
+  local params = {} --- @type string[]
   for _, p in ipairs(fun.params or {}) do
-    parts[#parts + 1] = string.format("%s: %s", p.name, p.type)
+    params[#params + 1] = string.format("%s: %s", p.name, p.type)
   end
+  parts[#parts + 1] = table.concat(params, ", ")
   parts[#parts + 1] = ")"
   if fun.returns then
     parts[#parts + 1] = ": "
@@ -250,6 +260,7 @@ local function fun2field(fun)
     type = table.concat(parts, ""),
     access = fun.access,
     desc = fun.desc,
+    overloads = fun.overloads,
   }
 end
 

--- a/lua/docgen/renderer.lua
+++ b/lua/docgen/renderer.lua
@@ -257,6 +257,18 @@ local function render_fields_or_params(objs, generics, classes)
     if p.type or p.desc then indent = math.max(indent, #p.name + 3) end
   end
 
+  local function render_field_overloads(overloads)
+    if not overloads or #overloads == 0 then return "" end
+
+    local header_indent = string.format("%s    ", TAB)
+    local bullet_indent = string.format("%s      ", TAB)
+    local chunks = { "\n", string.format("%sOverloads: ~\n", header_indent) }
+    for _, overload in ipairs(overloads) do
+      table.insert(chunks, string.format("%s• `%s`\n", bullet_indent, overload))
+    end
+    return table.concat(chunks)
+  end
+
   local indent_offset = indent + 9
   for i, obj in ipairs(objs) do
     local desc, default = get_default(obj.desc)
@@ -264,6 +276,7 @@ local function render_fields_or_params(objs, generics, classes)
 
     inline_type(obj, classes)
     desc = obj.desc
+    local overload_text = render_field_overloads(obj.overloads)
 
     local fname = obj.kind == "operator" and string.format("op(%s)", obj.name)
       or format_field_name(obj.name)
@@ -278,21 +291,30 @@ local function render_fields_or_params(objs, generics, classes)
           vim.list_extend(res, { " ", pty, "\n" })
           desc = M.render_markdown(desc, indent_offset, indent_offset)
           table.insert(res, desc)
+          if overload_text ~= "" then table.insert(res, overload_text) end
           table.insert(res, "\n")
         else
           desc = string.format("%s %s", pty, desc)
           desc = M.render_markdown(desc, #pname, indent_offset):gsub("^ *", "")
           table.insert(res, string.format(" %s\n", desc))
+          if overload_text ~= "" then table.insert(res, overload_text) end
         end
 
-        if has_blank_line(desc) and i ~= #objs then table.insert(res, "\n") end
+        if (has_blank_line(desc) or overload_text ~= "") and i ~= #objs then
+          table.insert(res, "\n")
+        end
       else
         table.insert(res, string.format("%s %s\n", pname, pty))
+        if overload_text ~= "" then
+          table.insert(res, overload_text)
+          if i ~= #objs then table.insert(res, "\n") end
+        end
       end
     else
       if desc then
         table.insert(res, pname)
         table.insert(res, M.render_markdown(desc, 1, indent_offset))
+        if overload_text ~= "" then table.insert(res, overload_text) end
         table.insert(res, "\n")
       end
     end
@@ -476,6 +498,14 @@ local function render_fun(fun, classes, section)
       table.insert(res, return_text)
       table.insert(res, "\n")
     end
+  end
+
+  if fun.overloads and #fun.overloads > 0 then
+    table.insert(res, string.format("%sOverloads: ~\n", TAB))
+    for _, overload in ipairs(fun.overloads) do
+      table.insert(res, string.format("%s  • `%s`\n", TAB, overload))
+    end
+    table.insert(res, "\n")
   end
 
   if fun.see and #fun.see > 0 then

--- a/tests/luacats_grammar_spec.lua
+++ b/tests/luacats_grammar_spec.lua
@@ -204,6 +204,29 @@ describe("fields", function()
   })
 end)
 
+describe("async", function()
+  test("@async", { kind = "async" })
+end)
+
+describe("overload", function()
+  test("@overload fun(x: string): boolean", {
+    kind = "overload",
+    type = "fun(x: string): boolean",
+  })
+
+  test("@overload fun(): nil", {
+    kind = "overload",
+    type = "fun(): nil",
+  })
+end)
+
+describe("enum", function()
+  test("@enum MyEnum", {
+    kind = "enum",
+    name = "MyEnum",
+  })
+end)
+
 describe("types", function()
   local types = require("docgen.grammar.types")
   ---@param idx integer

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -126,4 +126,98 @@ return M
     local _, actual, _, _ = parser.parse_str(input, "myfile.lua")
     assert.same(expect, actual)
   end)
+
+  it("@async sets async=true", function()
+    local input = [[
+local M = {}
+---@async
+---@param x string
+function M.myfunc(x) end
+return M
+    ]]
+    local _, funs, _, _ = parser.parse_str(input, "myfile.lua")
+    assert.same(true, funs[1].async)
+  end)
+
+  it("@overload accumulates overloads", function()
+    local input = [[
+local M = {}
+---@overload fun(x: string): boolean
+---@overload fun(x: number): string
+---@param x string
+function M.myfunc(x) end
+return M
+    ]]
+    local _, funs, _, _ = parser.parse_str(input, "myfile.lua")
+    assert.same({ "fun(x: string): boolean", "fun(x: number): string" }, funs[1].overloads)
+  end)
+
+  it("@overload is preserved for class methods converted to fields", function()
+    local input = [[
+local M = {}
+---@class MyClass
+local MyClass = {}
+---@overload fun(self: MyClass, x: string): boolean
+---@overload fun(self: MyClass, x: number): string
+---@param x string
+function MyClass:myfunc(x) end
+return M
+    ]]
+    local classes, _, _, _ = parser.parse_str(input, "myfile.lua")
+    assert.same(
+      { "fun(self: MyClass, x: string): boolean", "fun(self: MyClass, x: number): string" },
+      classes.MyClass.fields[1].overloads
+    )
+  end)
+end)
+
+describe("enum", function()
+  local function assert_no_output(input)
+    local classes, funs, briefs, uncommitted = parser.parse_str(input, "myfile.lua")
+    assert.same({}, classes)
+    assert.same({}, funs)
+    assert.same({}, briefs)
+    assert.same({}, uncommitted)
+  end
+
+  it("local enum produces no output", function()
+    assert_no_output([[
+local M = {}
+---@enum MyColors
+local MyColors = { red = 1, blue = 2 }
+return M
+    ]])
+  end)
+
+  it("module enum produces no output", function()
+    assert_no_output([[
+local M = {}
+---@enum MyColors
+M.MyColors = { red = 1, blue = 2 }
+return M
+    ]])
+  end)
+
+  it("does not swallow annotations meant for the next declaration", function()
+    -- this is not spec compliant Lua type annotation but to make sure we're saying
+    -- relatively resiliant to user errors where we can.
+    local input = [[
+local M = {}
+---@enum MyColors
+---@param x string
+function M.myfunc(x) end
+return M
+    ]]
+    local _, funs, _, _ = parser.parse_str(input, "myfile.lua")
+    assert.same({
+      {
+        module = "myfile.lua",
+        modvar = "M",
+        name = "myfunc",
+        params = {
+          { name = "x", type = "string" },
+        },
+      },
+    }, funs)
+  end)
 end)

--- a/tests/renderer_spec.lua
+++ b/tests/renderer_spec.lua
@@ -355,6 +355,27 @@ foo_bar.fire_employee({emp})                         *foo.bar.fire_employee()*
     assert_funs(input, expect)
   end)
 
+  it("overloads", function()
+    local input = [[
+---@overload fun(x: string): boolean
+---@overload fun(x: number): string
+---@param x string
+function M.myfunc(x) end
+    ]]
+
+    local expect = [[
+foo_bar.myfunc({x})                                         *foo.bar.myfunc()*
+    Parameters: ~
+      • {x}  (`string`)
+
+    Overloads: ~
+      • `fun(x: string): boolean`
+      • `fun(x: number): string`
+    ]]
+
+    assert_funs(input, expect)
+  end)
+
   it("default params", function()
     local input = [[
 ---@param x string some string (default: `"hello"`)
@@ -383,6 +404,30 @@ describe("classes", function()
     local actual = renderer.render_classes(classes, classes):gsub("[ \n]+$", "")
     assert_lines(expect, actual, { classes = classes })
   end
+
+  it("renders method overloads on class fields", function()
+    local input = [[
+---@class MyClass
+local MyClass = {}
+
+--- some method
+---@overload fun(self: MyClass, x: string): boolean
+---@overload fun(self: MyClass, x: number): string
+---@param x string
+function MyClass:myfunc(x) end
+    ]]
+    local expect = [[
+*MyClass*
+
+    Fields: ~
+      • {myfunc}  (`fun(self: MyClass, x: string)`) some method
+
+        Overloads: ~
+          • `fun(self: MyClass, x: string): boolean`
+          • `fun(self: MyClass, x: number): string`
+    ]]
+    assert_classes(input, expect)
+  end)
 
   it("basic", function()
     local input = [[


### PR DESCRIPTION
Really only going to render `@overload` in help docs but parsing `@async` and `@enum` maybe for future use.